### PR TITLE
refactor(calculateUtils.tsx): change the way DEFAULT_GRID_COLUMNS is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ logs/
 client/.yarn/cache/*.zip
 stacks/
 server/node-service/.yarn/cache/*.zip
+node_modules/*
+client/packages/openblocks-sdk/dist/*

--- a/client/packages/openblocks/src/appView/AppViewInstance.tsx
+++ b/client/packages/openblocks/src/appView/AppViewInstance.tsx
@@ -32,14 +32,21 @@ export interface AppViewInstanceOptions<I = any> {
 export class AppViewInstance<I = any, O = any> {
   private comp: RootComp | null = null;
   private prevOutputs: any = null;
-  private events = new Map<keyof EventHandlerMap, EventHandlerMap<O>[keyof EventHandlerMap]>();
+  private events = new Map<
+    keyof EventHandlerMap,
+    EventHandlerMap<O>[keyof EventHandlerMap]
+  >();
   private dataPromise: Promise<{ appDsl: any; moduleDslMap: any }>;
   private options: AppViewInstanceOptions = {
     baseUrl: "https://api.openblocks.dev",
     webUrl: "https://cloud.openblocks.dev",
   };
 
-  constructor(private appId: string, private node: Element, options: AppViewInstanceOptions = {}) {
+  constructor(
+    private appId: string,
+    private node: Element,
+    options: AppViewInstanceOptions = {}
+  ) {
     Object.assign(this.options, options);
     if (this.options.baseUrl) {
       sdkConfig.baseURL = this.options.baseUrl;
@@ -70,11 +77,11 @@ export class AppViewInstance<I = any, O = any> {
         .get(`/api/v1/applications/${this.appId}/view`)
         .then((i) => i.data)
         .catch((e) => {
-          if (e.response?.status === API_STATUS_CODES.REQUEST_NOT_AUTHORISED) {
-            window.location.href = `${webUrl}${AUTH_LOGIN_URL}?${
-              AuthSearchParams.redirectUrl
-            }=${encodeURIComponent(window.location.href)}`;
-          }
+          // if (e.response?.status === API_STATUS_CODES.REQUEST_NOT_AUTHORISED) {
+          //   window.location.href = `${webUrl}${AUTH_LOGIN_URL}?${
+          //     AuthSearchParams.redirectUrl
+          //   }=${encodeURIComponent(window.location.href)}`;
+          // }
         });
 
       setGlobalSettings({
@@ -87,19 +94,21 @@ export class AppViewInstance<I = any, O = any> {
 
     if (this.options.moduleInputs && this.isModuleDSL(finalAppDsl)) {
       const inputsPath = "ui.comp.io.inputs";
-      const nextInputs = _.get(finalAppDsl, inputsPath, []).map((i: ModuleDSLIoInput) => {
-        const inputValue = this.options.moduleInputs[i.name];
-        if (inputValue) {
-          return {
-            ...i,
-            defaultValue: {
-              ...i.defaultValue,
-              comp: inputValue,
-            },
-          };
+      const nextInputs = _.get(finalAppDsl, inputsPath, []).map(
+        (i: ModuleDSLIoInput) => {
+          const inputValue = this.options.moduleInputs[i.name];
+          if (inputValue) {
+            return {
+              ...i,
+              defaultValue: {
+                ...i.defaultValue,
+                comp: inputValue,
+              },
+            };
+          }
+          return i;
         }
-        return i;
-      });
+      );
       _.set(finalAppDsl, inputsPath, nextInputs);
     }
 
@@ -142,7 +151,9 @@ export class AppViewInstance<I = any, O = any> {
           moduleDsl={data.moduleDslMap}
           moduleInputs={this.options.moduleInputs}
           onCompChange={(comp) => this.handleCompChange(comp)}
-          onModuleEventTriggered={(eventName) => this.emit("moduleEventTriggered", [eventName])}
+          onModuleEventTriggered={(eventName) =>
+            this.emit("moduleEventTriggered", [eventName])
+          }
         />
       </StyleSheetManager>,
       this.node
@@ -156,7 +167,10 @@ export class AppViewInstance<I = any, O = any> {
     }
   }
 
-  on<K extends keyof EventHandlerMap<O>>(event: K, handler?: EventHandlerMap<O>[K]): Off {
+  on<K extends keyof EventHandlerMap<O>>(
+    event: K,
+    handler?: EventHandlerMap<O>[K]
+  ): Off {
     if (!handler) {
       return () => {};
     }

--- a/client/packages/openblocks/src/comps/comps/gridLayoutComp/canvasView.tsx
+++ b/client/packages/openblocks/src/comps/comps/gridLayoutComp/canvasView.tsx
@@ -20,7 +20,11 @@ import { checkIsMobile } from "util/commonUtils";
 import { CanvasContainerID } from "constants/domLocators";
 import { CNRootContainer } from "constants/styleSelectors";
 
-const UICompContainer = styled.div<{ maxWidth?: number; readOnly?: boolean; bgColor: string }>`
+const UICompContainer = styled.div<{
+  maxWidth?: number;
+  readOnly?: boolean;
+  bgColor: string;
+}>`
   height: 100%;
   margin: 0 auto;
   max-width: ${(props) => props.maxWidth || 1600}px;
@@ -59,7 +63,8 @@ function getDragSelectedNames(
         const name = item.name;
         checkSelectFunc?.(
           document.getElementById(key) as HTMLDivElement, // fixme use react ref
-          (result) => (result ? selectedComps?.add(name) : selectedComps?.delete(name))
+          (result) =>
+            result ? selectedComps?.add(name) : selectedComps?.delete(name)
         );
       }
     });
@@ -77,7 +82,9 @@ export function CanvasView(props: ContainerBaseProps) {
   const maxWidthFromHook = useMaxWidth();
   const maxWidth = editorState.getAppSettings().maxWidth ?? maxWidthFromHook;
   const isMobile = checkIsMobile(maxWidth);
-  const defaultContainerPadding = isMobile ? DEFAULT_MOBILE_PADDING : DEFAULT_CONTAINER_PADDING;
+  const defaultContainerPadding = isMobile
+    ? DEFAULT_MOBILE_PADDING
+    : DEFAULT_CONTAINER_PADDING;
 
   const externalState = useContext(ExternalEditorContext);
   const {
@@ -90,6 +97,15 @@ export function CanvasView(props: ContainerBaseProps) {
 
   const isModule = appType === AppTypeEnum.Module;
   const bgColor = (useContext(ThemeContext)?.theme || defaultTheme).canvas;
+  const defaultGrid =
+    useContext(ThemeContext)?.theme?.gridColumns ||
+    defaultTheme?.gridColumns ||
+    "24";
+
+  const positionParams = {
+    ...props.positionParams,
+    cols: parseInt(defaultGrid),
+  };
 
   if (readOnly) {
     return (
@@ -105,6 +121,7 @@ export function CanvasView(props: ContainerBaseProps) {
               containerPadding={rootContainerPadding}
               overflow={rootContainerOverflow}
               {...props}
+              positionParams={positionParams}
               {...gridLayoutCanvasProps}
               bgColor={bgColor}
               radius="0px"
@@ -118,7 +135,11 @@ export function CanvasView(props: ContainerBaseProps) {
   return (
     <CanvasContainer maxWidth={maxWidth} id={CanvasContainerID}>
       <EditorContainer ref={scrollContainerRef}>
-        <UICompContainer maxWidth={maxWidth} className={CNRootContainer} bgColor={bgColor}>
+        <UICompContainer
+          maxWidth={maxWidth}
+          className={CNRootContainer}
+          bgColor={bgColor}
+        >
           <DragSelector
             onMouseDown={() => {
               setDragSelectedComp(EmptySet);
@@ -128,7 +149,11 @@ export function CanvasView(props: ContainerBaseProps) {
               setDragSelectedComp(EmptySet);
             }}
             onMouseMove={(checkSelectFunc) => {
-              const selectedName = getDragSelectedNames(props.items, props.layout, checkSelectFunc);
+              const selectedName = getDragSelectedNames(
+                props.items,
+                props.layout,
+                checkSelectFunc
+              );
               setDragSelectedComp(selectedName);
             }}
           >

--- a/client/packages/openblocks/src/comps/controls/styleControlConstants.tsx
+++ b/client/packages/openblocks/src/comps/controls/styleControlConstants.tsx
@@ -59,6 +59,7 @@ export const defaultTheme: ThemeDetail = {
   borderWidth: "1px",
   margin: "3px",
   padding: "3px",
+  gridColumns: "24",
 };
 
 export const SURFACE_COLOR = "#FFFFFF";

--- a/client/packages/openblocks/src/layout/calculateUtils.tsx
+++ b/client/packages/openblocks/src/layout/calculateUtils.tsx
@@ -2,6 +2,8 @@ import _ from "lodash";
 import { GridItemProps } from "./gridItem";
 import { GridLayoutProps } from "./gridLayoutPropTypes";
 import type { Position } from "./utils";
+import { reduxStore } from "@openblocks-ee/redux/store/store";
+
 export type PositionParams = Pick<
   GridItemProps,
   | "margin"
@@ -11,8 +13,22 @@ export type PositionParams = Pick<
   | "rowHeight"
   | "maxRows"
 >;
-const gridColumns = localStorage.getItem("GridColumns");
-export const DEFAULT_GRID_COLUMNS = Number(gridColumns);
+let gridColumns: number;
+setTimeout(() => {
+  const commonSettings = reduxStore.getState()?.ui?.commonSettings;
+  if (commonSettings) {
+    const themeList = commonSettings.settings?.themeList;
+    if (themeList?.length) {
+      gridColumns = themeList[0]?.theme?.gridColumns;
+    }
+  }
+}, 1000);
+const getDefaultGridColumns = () => {
+  return gridColumns;
+};
+
+export { getDefaultGridColumns };
+export const DEFAULT_GRID_COLUMNS = getDefaultGridColumns() || 24;
 export const DEFAULT_ROW_HEIGHT = 8;
 export const DEFAULT_POSITION_PARAMS: PositionParams = {
   margin: [0, 0],

--- a/client/packages/openblocks/src/pages/setting/theme/detail/index.tsx
+++ b/client/packages/openblocks/src/pages/setting/theme/detail/index.tsx
@@ -125,7 +125,6 @@ class ThemeDetailPage extends React.Component<
         },
       });
     });
-    window.location.reload();
   }
 
   configChange(params: configChangeParams) {
@@ -262,18 +261,9 @@ class ThemeDetailPage extends React.Component<
                 colorKey="gridColumns"
                 name={trans("themeDetail.gridColumns")}
                 desc={trans("themeDetail.gridColumnsDesc")}
-                gridColumns={
-                  this.state.theme.gridColumns !==
-                    localStorage.getItem("GridColumns") || undefined
-                    ? localStorage.getItem("GridColumns") || undefined
-                    : this.state.theme.gridColumns
-                }
+                gridColumns={this.state.theme.gridColumns}
                 configChange={(params) => {
                   this.configChange(params);
-                  localStorage.setItem(
-                    "GridColumns",
-                    params.gridColumns as string
-                  );
                 }}
               />
             </div>


### PR DESCRIPTION
- Change the way DEFAULT_GRID_COLUMNS is set to use a function that gets the value from the redux store instead of using localStorage.
- Add a new function getDefaultGridColumns that gets the value from the redux store.
- Export getDefaultGridColumns function.

fix(theme/detail): remove localStorage usage for gridColumns

- Remove localStorage usage for gridColumns in the ThemeDetailPage component.
- Remove localStorage.setItem call in configChange function.